### PR TITLE
RHEL9-STIG-Audit: fix 271065 goss path + 611180/232225/654190 titles (V2R8 XCCDF)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ corrected 8 malformed CCI metadata values missing leading zeros to their 6-digit
 reconciled two touched rules to the V2R8 XCCDF: RHEL-09-252020 added CCI-004923 and CCI-004926, and RHEL-09-411070 Vul_ID corrected V-258052 to V-258053
 
 RHEL-09-611180: goss now checks the pcscd socket (`pcscd.socket`) instead of the pcscd service, per the V2R8 XCCDF check-content (`systemctl is-active pcscd.socket`). Title left as the DISA-verbatim "pcscd service". Mirrors the RHEL10-STIG-Audit RHEL-10-200611 fix.
+RHEL-09-271065: fixed a double-`.d` in the goss path (`{{ rhel9stig_dconf_db }}.d/00-screensaver` rendered `local.d.d`); dropped the stray literal `.d` so it matches the remediated path `local.d/00-screensaver` (and sibling 271075)
+RHEL-09-232225: corrected goss title "owned" -> "group-owned" (the check uses `stat -c %G`); RHEL-09-654190: corrected goss title "init command" -> "poweroff command" (the check targets `/usr/sbin/poweroff`)
 run_audit.sh: read only the first line of `goss -v` (awk NR==1) so a multi-line goss banner cannot corrupt the parsed version; fixed two message typos ("needs to run", "does not meet minimum")
 
 Full goss metadata reconciliation to the V2R8 XCCDF (80 rule files). Coverage 446/446, all Cat/severity already correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ relaxed the same over-strict aide regex on RHEL-09-651030 (verifies `acl`) and R
 corrected 8 malformed CCI metadata values missing leading zeros to their 6-digit XCCDF values: RHEL-09-252035, RHEL-09-252045, RHEL-09-252050, RHEL-09-411065, RHEL-09-411070 (CCI-000366), RHEL-09-411040 (CCI-000016), RHEL-09-411045 (CCI-000764), RHEL-09-672020 (CCI-003123)
 reconciled two touched rules to the V2R8 XCCDF: RHEL-09-252020 added CCI-004923 and CCI-004926, and RHEL-09-411070 Vul_ID corrected V-258052 to V-258053
 
-RHEL-09-611180: goss now checks the pcscd socket (`pcscd.socket`) instead of the pcscd service, per the V2R8 XCCDF check-content (`systemctl is-active pcscd.socket`); title updated. Mirrors the RHEL10-STIG-Audit RHEL-10-200611 fix.
+RHEL-09-611180: goss now checks the pcscd socket (`pcscd.socket`) instead of the pcscd service, per the V2R8 XCCDF check-content (`systemctl is-active pcscd.socket`). Title left as the DISA-verbatim "pcscd service". Mirrors the RHEL10-STIG-Audit RHEL-10-200611 fix.
 run_audit.sh: read only the first line of `goss -v` (awk NR==1) so a multi-line goss banner cannot corrupt the parsed version; fixed two message typos ("needs to run", "does not meet minimum")
 
 Full goss metadata reconciliation to the V2R8 XCCDF (80 rule files). Coverage 446/446, all Cat/severity already correct.

--- a/cat_2/RHEL-09-23xxxx/RHEL-09-232225.yml
+++ b/cat_2/RHEL-09-23xxxx/RHEL-09-232225.yml
@@ -3,7 +3,7 @@
 {{ if .Vars.rhel_09_232225 }}
 command:
   audit_bins_root_group:
-    title: RHEL-09-232225 | RHEL 9 audit tools must be owned by root.
+    title: RHEL-09-232225 | RHEL 9 audit tools must be group-owned by root.
     exec: stat -c "%G" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/rsyslogd /sbin/augenrules | uniq | tr -d '\n'
     exit-status: 0
     stdout:

--- a/cat_2/RHEL-09-27xxxx/RHEL-09-271065.yml
+++ b/cat_2/RHEL-09-27xxxx/RHEL-09-271065.yml
@@ -4,7 +4,7 @@
 file:
   gui_screensaver_timeout:
     title: RHEL-09-271065 | RHEL 9 must automatically lock graphical user sessions after 10 minutes of inactivity.
-    path: /etc/dconf/db/{{ .Vars.rhel9stig_dconf_db }}.d/00-screensaver
+    path: /etc/dconf/db/{{ .Vars.rhel9stig_dconf_db }}/00-screensaver
     exists: true
     contents:
     - '/^\[org\/gnome\/desktop\/session\]$/'

--- a/cat_2/RHEL-09-61xxxx/RHEL-09-611180.yml
+++ b/cat_2/RHEL-09-61xxxx/RHEL-09-611180.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.rhel9stig_smartcard_reader }}
 service:
   pcscd_running:
-    title: RHEL-09-611180 | The pcscd socket on RHEL 9 must be active.
+    title: RHEL-09-611180 | The pcscd service on RHEL 9 must be active.
     name: pcscd.socket
     running: true
     enabled: true

--- a/cat_2/RHEL-09-654xxx/RHEL-09-654190.yml
+++ b/cat_2/RHEL-09-654xxx/RHEL-09-654190.yml
@@ -3,7 +3,7 @@
 {{ if .Vars.rhel_09_654190 }}
 file:
   audit_conf_poweroff:
-    title: RHEL-09-654190 | Successful/unsuccessful uses of the init command in RHEL 9 must generate an audit record.
+    title: RHEL-09-654190 | Successful/unsuccessful uses of the poweroff command in RHEL 9 must generate an audit record.
     exists: true
     path: /etc/audit/rules.d/audit.rules
     contents:
@@ -21,7 +21,7 @@ file:
       Vul_ID: V-258212
 command:
   audit_running_poweroff:
-    title: RHEL-09-654190 | Successful/unsuccessful uses of the init command in RHEL 9 must generate an audit record.
+    title: RHEL-09-654190 | Successful/unsuccessful uses of the poweroff command in RHEL 9 must generate an audit record.
     exec: auditctl -l | grep -w "poweroff"
     exit-status:
       or:


### PR DESCRIPTION
I understand and have followed the [contributing guide](https://github.com/ansible-lockdown/RHEL9-STIG-Audit/blob/devel/CONTRIBUTING.rst).

All commits are signed off (DCO) and GPG-signed.

**Overall Review of Changes:**

Follow-up to the merged V2R8 audit work (PRs #17/#18/#19). These three fixes were prepared after PR #19 merged, so they need their own PR into `benchmark_v2r8`. One functional goss-path fix plus three DISA-title corrections; all verified against the RHEL 9 STIG V2R8 XCCDF.

**Enhancements:**

- **RHEL-09-271065** (functional) - the goss path `/etc/dconf/db/{{ rhel9stig_dconf_db }}.d/00-screensaver` rendered `local.d.d` (the var already ends in `.d`), so the check failed on a correctly-remediated host. Dropped the stray literal `.d` to render `local.d/00-screensaver`, matching the remediation role and sibling 271075.
- **RHEL-09-611180** - reverted the goss title to the DISA-verbatim "The pcscd service on RHEL 9 must be active." The V2R8 XCCDF rule title reads "service"; only the check-content/fixtext reference the socket (the check still targets `pcscd.socket`, unchanged from PR #19).
- **RHEL-09-232225** - goss title "owned" -> "group-owned" (the check uses `stat -c %G`).
- **RHEL-09-654190** - goss title "init command" -> "poweroff command" (the check targets `/usr/sbin/poweroff`).

**How has this been tested?:**

- All changed goss files retain their `---` document markers and `{{ if }}`/`{{ end }}` guards; meta unchanged.
- 271065 path verified against the remediation role output (`local.d/00-screensaver`) and sibling 271075.
- Titles verified verbatim against the V2R8 XCCDF (`<title>` for SV-258125, SV-257925, SV-258212).
- CHANGELOG updated.
