### PR TITLE
Make RHEL-09-252035 DNS check systemd-resolved aware (addresses #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Based on STIG V2R8 - 2026 benchmark_v2r8 cycle
 
+RHEL-09-252035 (addresses #31; thank you @mbc3): made the two-name-server check DNS-mode-aware. When rhel9stig_dns_processing_mode is 'systemd-resolved' the check now validates the DNS= key (at least two servers) in /etc/systemd/resolved.conf (+ resolved.conf.d/*.conf) via a command resource, since under systemd-resolved /etc/resolv.conf holds only the 127.0.0.53 stub; otherwise it keeps the existing /etc/resolv.conf nameserver check. Added a rhel9stig_dns_processing_mode default (none) to vars/STIG.yml; the paired remediation role exposes the live value through the goss bridge template
 V2R8 benchmark bump (446 -> 446 rules; updates-only, no add/remove)
 8 goss files moved cat_2/RHEL-09-NNxxxx/ subdirs -> cat_1/ flat for severity-bumped rules (215100, 215105, 255064, 255065, 255070, 255075, 671020, 672050) with Cat: 2 -> Cat: 1 in goss metadata
 46 Rule_ID metadata lines updated to V2R8 SV-* values (27 expected from V2R7 -> V2R8 XCCDF + 19 pre-existing audit-repo drifts surfaced)

--- a/cat_2/RHEL-09-25xxxx/RHEL-09-252035.yml
+++ b/cat_2/RHEL-09-25xxxx/RHEL-09-252035.yml
@@ -1,6 +1,26 @@
 ---
 
 {{ if .Vars.rhel_09_252035 }}
+{{ if eq .Vars.rhel9stig_dns_processing_mode "systemd-resolved" }}
+command:
+  resolved_nameservers:
+    title: RHEL-09-252035 | RHEL 9 systems using Domain Name Servers (DNS) resolution must have at least two name servers configured.
+    exec: cat /etc/systemd/resolved.conf /etc/systemd/resolved.conf.d/*.conf 2>/dev/null | grep -E '^[[:space:]]*DNS='
+    exit-status: 0
+    stdout:
+    - '/^\s*DNS=(\S+\s+)+\S+/'
+    meta:
+      Cat: 2
+      CCI:
+      - CCI-000366
+      Group_Title:
+      - SRG-OS-000480-GPOS-00227
+      NIST800-53R4:
+      - CM-6
+      Rule_ID: SV-257948r1045004_rule
+      STIG_ID: RHEL-09-252035
+      Vul_ID: V-257948
+{{ else }}
 file:
   resolv_nameservers:
     title: RHEL-09-252035 | RHEL 9 systems using Domain Name Servers (DNS) resolution must have at least two name servers configured.
@@ -20,4 +40,5 @@ file:
       Rule_ID: SV-257948r1045004_rule
       STIG_ID: RHEL-09-252035
       Vul_ID: V-257948
+{{ end }}
 {{ end }}

--- a/vars/STIG.yml
+++ b/vars/STIG.yml
@@ -570,6 +570,10 @@ rhel9stig_white_list_services:
 - ssh
 
 # dns
+# Set to 'systemd-resolved' when NetworkManager delegates DNS to systemd-resolved;
+# the 252035 check then validates DNS= in /etc/systemd/resolved.conf instead of
+# /etc/resolv.conf (which holds only the 127.0.0.53 stub under systemd-resolved).
+rhel9stig_dns_processing_mode: none
 rhel9stig_dns_servers:
 - 8.8.8.8
 - 8.8.4.4


### PR DESCRIPTION
- [x] I have read and agree to the [Ansible Lockdown Code of Conduct](https://github.com/ansible-lockdown/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read and understand the [contributing guidelines](https://github.com/ansible-lockdown/.github/blob/main/CONTRIBUTING.md)

**Overall Review of Changes:**

Backports the benchmark_v2r9 fix to benchmark_v2r8. RHEL-09-252035 inspected only `/etc/resolv.conf` for the configured nameservers, so a host using systemd-resolved (where `resolv.conf` is the 127.0.0.53 stub and the real servers live in `/etc/systemd/resolved.conf`) reported a false finding.

When `rhel9stig_dns_processing_mode` is `systemd-resolved` the check now uses a `command` resource that greps `DNS=` from `/etc/systemd/resolved.conf` (+ `resolved.conf.d/*.conf`) and requires at least two servers; otherwise it keeps the existing `/etc/resolv.conf` nameserver check. Added a `rhel9stig_dns_processing_mode` default (`none`) to `vars/STIG.yml` so a standalone goss run resolves the toggle; the paired remediation exposes the live value via the goss bridge template.

**Issue Fixes:**

addresses #31

**Enhancements:**

DNS-mode-aware audit that stays correct for both classic resolv.conf and systemd-resolved managed hosts.

**How has this been tested?:**

Both goss template branches parse; the `DNS=` regex was behavior-tested (>= 2 servers pass; single/empty/commented/missing find). RHEL-09-252035 is container-gated, so molecule cannot exercise it; the live gate is the paired remediation repo real-CI. Paired remediation change in ansible-lockdown/Private-RHEL9-STIG.
