### PR TITLE
Make RHEL-09-252035 DNS check self-detecting (fix goss missingkey abort; addresses #29 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Based on STIG V2R9 - 2026 benchmark_v2r9 cycle
 
+RHEL-09-252035 (addresses #29 follow-up; thank you @mbc3): made the DNS check self-detecting and removed the hard dependency on the rhel9stig_dns_processing_mode goss var. The earlier systemd-resolved fix gated on `{{ if eq .Vars.rhel9stig_dns_processing_mode ... }}`, which goss evaluates with missingkey=error - so any host whose goss vars file lacked that key (e.g. a remediation role predating the bridge-template change) aborted the whole check ("map has no entry"). The check now counts non-stub nameservers in /etc/resolv.conf plus DNS= servers in /etc/systemd/resolved.conf(+.d) and passes when either provides at least two, with no .Vars dependency beyond the rule toggle - matching the self-detecting RHEL-10-800060 approach.
 V2R9 benchmark bump (446 -> 445 rules; 1 rule removed, 0 added). Coverage verified 445/445 against the V2R9 XCCDF.
 vars/STIG.yml benchmark_version bumped v2r8 -> v2r9; run_audit.sh BENCHMARK_VER v2r8 -> v2r9 (BENCHMARK_OS=RHEL9 unchanged); README banner updated v2r8/April -> v2r9/July 2026
 removed RHEL-09-255130 (V-258002, SSH daemon compression) per V2R9: deleted cat_2/RHEL-09-25xxxx/RHEL-09-255130.yml, the rhel_09_255130 toggle and the orphan sshd_config.compress value in vars/STIG.yml

--- a/cat_2/RHEL-09-25xxxx/RHEL-09-252035.yml
+++ b/cat_2/RHEL-09-25xxxx/RHEL-09-252035.yml
@@ -1,14 +1,13 @@
 ---
 
 {{ if .Vars.rhel_09_252035 }}
-{{ if eq .Vars.rhel9stig_dns_processing_mode "systemd-resolved" }}
 command:
-  resolved_nameservers:
+  dns_name_servers:
     title: RHEL-09-252035 | RHEL 9 systems using Domain Name Servers (DNS) resolution must have at least two name servers configured.
-    exec: cat /etc/systemd/resolved.conf /etc/systemd/resolved.conf.d/*.conf 2>/dev/null | grep -E '^[[:space:]]*DNS='
+    exec: r=$(grep -Ei '^nameserver[[:space:]]+' /etc/resolv.conf 2>/dev/null | grep -vcE '127\.0\.0\.53'); s=$(cat /etc/systemd/resolved.conf /etc/systemd/resolved.conf.d/*.conf 2>/dev/null | grep -iE '^[[:space:]]*DNS=' | sed 's/^[^=]*=//' | tr ' ' '\n' | grep -cE '[0-9a-fA-F.:]'); [ "$s" -gt "$r" ] && echo "$s" || echo "$r"
     exit-status: 0
     stdout:
-    - '/^\s*DNS=(\S+\s+)+\S+/'
+    - '/^([2-9]|[1-9][0-9]+)$/'
     meta:
       Cat: 2
       CCI:
@@ -20,25 +19,4 @@ command:
       Rule_ID: SV-257948r1045004_rule
       STIG_ID: RHEL-09-252035
       Vul_ID: V-257948
-{{ else }}
-file:
-  resolv_nameservers:
-    title: RHEL-09-252035 | RHEL 9 systems using Domain Name Servers (DNS) resolution must have at least two name servers configured.
-    path: /etc/resolv.conf
-    contents:
-    {{ range .Vars.rhel9stig_dns_servers }}
-    - {{ . }}
-    {{ end }}
-    meta:
-      Cat: 2
-      CCI:
-      - CCI-000366
-      Group_Title:
-      - SRG-OS-000480-GPOS-00227
-      NIST800-53R4:
-      - CM-6
-      Rule_ID: SV-257948r1045004_rule
-      STIG_ID: RHEL-09-252035
-      Vul_ID: V-257948
-{{ end }}
 {{ end }}


### PR DESCRIPTION
- [x] I have read and agree to the [Ansible Lockdown Code of Conduct](https://github.com/ansible-lockdown/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read and understand the [contributing guidelines](https://github.com/ansible-lockdown/.github/blob/main/CONTRIBUTING.md)

**Overall Review of Changes:**

Follow-up to the RHEL-09-252035 systemd-resolved fix. That change gated the check on `{{ if eq .Vars.rhel9stig_dns_processing_mode "systemd-resolved" }}`. goss renders templates with `missingkey=error`, so on any host whose goss vars file lacks that key - e.g. a remediation role predating the bridge-template change that emits it - the whole check aborts:

```
could not read json data in .../RHEL-09-252035.yml: ... map has no entry for key "rhel9stig_dns_processing_mode"
```

This rewrites the check to be **self-detecting**, with no `.Vars` dependency beyond the rule toggle (mirroring the self-detecting RHEL-10-800060): it counts non-stub `nameserver` lines in `/etc/resolv.conf` plus `DNS=` servers in `/etc/systemd/resolved.conf` (+ `resolved.conf.d/*.conf`) and passes when either location provides at least two. `FallbackDNS` is not counted; the count match accepts 10+ servers.

**Issue Fixes:**

addresses #29 (follow-up)

**Enhancements:**

Removes a version-skew failure mode - the audit no longer hard-aborts when the remediation vars file predates the DNS-mode variable, and it stays correct for both classic `resolv.conf` and systemd-resolved managed hosts.

**How has this been tested?:**

6-case behavior harness: classic 2 servers, systemd-resolved stub + `resolved.conf` 2 servers, and a plain 2-nameserver `resolv.conf` with no DNS-mode var all pass; single server, nothing configured, and stub+1 correctly find. Template renders and YAML parses. RHEL-09-252035 is container-gated, so the live gate is the paired remediation repo CI.
